### PR TITLE
Fix font name in barcode example

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,11 @@ func main() {
         Type: "text",
         Data: "VIP Access",
         Params: map[string]string{
-            "font": "Helvetica-Bold",
-            "size": "22",
-            "x":    "10",
-            "y":    "15",
+            "font":  "Helvetica",
+            "style": "B",
+            "size":  "22",
+            "x":     "10",
+            "y":     "15",
         },
     })
     tpl.AddItem(pdfgen.SpdfItem{


### PR DESCRIPTION
## Summary
- fix font declaration in the ticket example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684f2c0367f8832c9a2c75cfa8129d41