### PR TITLE
Fix advanced ticket README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,11 @@ func main() {
         Type: "text",
         Data: "Summer Festival 2024",
         Params: map[string]string{
-            "font": "Helvetica-Bold",
-            "size": "20",
-            "x":    "10",
-            "y":    "15",
+            "font":  "Helvetica",
+            "style": "B",
+            "size":  "20",
+            "x":     "10",
+            "y":     "15",
         },
     })
     tpl.AddItem(pdfgen.SpdfItem{


### PR DESCRIPTION
## Summary
- correct font params in advanced ticket example in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684f2dbcf148832c8cab0d38c944441a